### PR TITLE
Add support for bare sprockets projects

### DIFF
--- a/lib/parsley-rails.rb
+++ b/lib/parsley-rails.rb
@@ -6,6 +6,10 @@ module Parsley
       elsif sprockets?
         register_sprockets
       end
+      
+      if sass?
+        configure_sass
+      end
     end
 
     # Paths
@@ -34,7 +38,16 @@ module Parsley
       defined?(::Rails)
     end
 
+    def sass?
+      defined?(::Sass)
+    end
+
     private
+
+    def configure_sass
+      require 'sass'
+      ::Sass.load_paths << stylesheets_path
+    end
 
     def register_rails_engine
       require 'parsley-rails/engine'

--- a/lib/parsley-rails.rb
+++ b/lib/parsley-rails.rb
@@ -1,8 +1,50 @@
-require 'rails/engine'
-
 module Parsley
-  module Rails
-    class Engine < ::Rails::Engine
+  class << self
+    def load!
+      if rails?
+        register_rails_engine
+      elsif sprockets?
+        register_sprockets
+      end
+    end
+
+    # Paths
+    def gem_path
+      @gem_path ||= File.expand_path '..', File.dirname(__FILE__)
+    end
+
+    def stylesheets_path
+      File.join assets_path, 'stylesheets'
+    end
+
+    def javascripts_path
+      File.join assets_path, 'javascripts'
+    end
+
+    def assets_path
+      @assets_path ||= File.join gem_path, 'vendor/assets'
+    end
+
+    # Environment detection helpers
+    def sprockets?
+      defined?(::Sprockets)
+    end
+
+    def rails?
+      defined?(::Rails)
+    end
+
+    private
+
+    def register_rails_engine
+      require 'parsley-rails/engine'
+    end
+
+    def register_sprockets
+      Sprockets.append_path(stylesheets_path)
+      Sprockets.append_path(javascripts_path)
     end
   end
 end
+
+Parsley.load!

--- a/lib/parsley-rails/engine.rb
+++ b/lib/parsley-rails/engine.rb
@@ -1,0 +1,8 @@
+require 'rails/engine'
+
+module Parsley
+  module Rails
+    class Engine < ::Rails::Engine
+    end
+  end
+end

--- a/parsley-rails.gemspec
+++ b/parsley-rails.gemspec
@@ -15,6 +15,4 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split($/)
   gem.require_paths = ["lib"]
-
-  gem.add_dependency("railties", ">= 3.0.0")
 end


### PR DESCRIPTION
This PR adds a load-time check to determine the kind of asset pipeline in use. It's based on the code the bootstrap gem uses, which can be seen here: https://github.com/twbs/bootstrap-rubygem/blob/master/lib/bootstrap.rb

Specifically, it adds the asset paths to the Sprockets load-path if it detects Sprockets being used outside of Rails.

I've verified that this works for me locally, but since this project doesn't currently have a test suite set up I've not added any with this pull.

I've not updated the version number either.